### PR TITLE
Use ZeresPluginLibrary new download url

### DIFF
--- a/templates/plugin.template.js
+++ b/templates/plugin.template.js
@@ -50,7 +50,7 @@ module.exports = window.hasOwnProperty("ZeresPluginLibrary")
                     cancelText: "Cancel",
                     onConfirm: () => {
                         require("request").get("https://rauenzi.github.io/BDPluginLibrary/release/0PluginLibrary.plugin.js", async (error, response, body) => {
-                            if (error) return require("electron").shell.openExternal("https://betterdiscord.net/ghdl?url=https://raw.githubusercontent.com/rauenzi/BDPluginLibrary/master/release/0PluginLibrary.plugin.js");
+                            if (error) return require("electron").shell.openExternal("https://betterdiscord.app/Download?id=9");
                             await new Promise(r => require("fs").writeFile(require("path").join(BdApi.Plugins.folder, "0PluginLibrary.plugin.js"), body, r));
                         });
                     }


### PR DESCRIPTION
Replaces the ZeresPluginLibrary fallback download URL with the new website URL.